### PR TITLE
Limit the parallelism of user Chromium builds to 8 using an alias

### DIFF
--- a/chromium/chromium-update.dockerfile
+++ b/chromium/chromium-update.dockerfile
@@ -8,8 +8,10 @@ RUN sudo apt-get update -q && sudo apt-get upgrade -qy
 RUN cd /home/user/depot_tools \
  && git pull --rebase origin master
 
-# Update and rebuild Chromium's source code.
-RUN cd /home/user/chromium/src \
+# Remove the parallelism limited Ninja alias and
+# update and rebuild Chromium's source code.
+RUN unalias ninja \
+ && cd /home/user/chromium/src \
  && git fetch origin \
  && git reset --hard origin/master \
  && gclient sync --delete --jobs=`nproc` \

--- a/chromium/chromium.dockerfile
+++ b/chromium/chromium.dockerfile
@@ -4,7 +4,10 @@ FROM janitortechnology/ubuntu-dev
 RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
 ENV PATH $PATH:/home/user/depot_tools
 RUN echo "\n# Add Chromium's depot_tools to the PATH." >> .bashrc \
- && echo "export PATH=\"\$PATH:/home/user/depot_tools\"" >> .bashrc
+ && echo "export PATH=\"\$PATH:/home/user/depot_tools\"" >> .bashrc \
+
+# Make default Ninja parallelism use 8 parallel jobs.
+RUN echo "\nalias ninja='ninja -j8'" >> .bash_aliases
 
 # Enable bash completion for git cl.
 RUN echo "\n# The next line enables bash completion for git cl." >> .bashrc \


### PR DESCRIPTION
But temporarily remove the alias before building the image itself.